### PR TITLE
Fix link to stream condition

### DIFF
--- a/action/context/lightstep.js
+++ b/action/context/lightstep.js
@@ -40,7 +40,7 @@ const getApiContext = async ({lightstepProj, lightstepOrg, lightstepToken, light
     const conditionStatuses = conditionStatusResponses.map(s => {
         const cleanId = s.body.data.id.replace('-status', '')
         const streamLink =
-            `https://app.lightstep.com/demo/stream/${conditionStreams[cleanId]}?selected_condition_id=${cleanId}`
+            `https://${LIGHTSTEP_WEB_HOST}/${lightstepProj}/stream/${conditionStreams[cleanId]}?selected_condition_id=${cleanId}`
         return {
             id          : cleanId,
             stream      : conditionStreams[cleanId],


### PR DESCRIPTION
The link to stream conditions on the comment left by the action was broken. This PR properly composes the link by including the lightstep project in the path instead of `demo` and utilizes the `LIGHTSTEP_WEB_HOST` variable instead of the hardcoded URL.